### PR TITLE
feat: add middleware as project guard

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -1,13 +1,18 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { HealthModule } from './health/health.module';
 import { AppController } from './app.controller';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { ProjectModule } from './project/project.module';
+import { ProjectGuard } from './project/project.guard';
 
 @Module({
   imports: [HealthModule, UserModule, AuthModule, ProjectModule],
   controllers: [AppController],
   providers: []
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(ProjectGuard).exclude('/(health|projects)(/.*)?').forRoutes('/');
+  }
+}

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -12,7 +12,7 @@ import { ProjectGuard } from './project/project.guard';
   providers: []
 })
 export class AppModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
+  configure(consumer: MiddlewareConsumer): void {
     consumer.apply(ProjectGuard).exclude('/(health|projects)(/.*)?').forRoutes('/');
   }
 }

--- a/packages/server/src/project/project.guard.ts
+++ b/packages/server/src/project/project.guard.ts
@@ -1,9 +1,13 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import { NextFunction } from 'express';
+import { NextFunction, Request, Response } from 'express';
+import { ProjectService } from './project.service';
 
 @Injectable()
 export class ProjectGuard implements NestMiddleware {
-  use(req: Request, res: Response, next: NextFunction) {
+  constructor(private readonly projectService: ProjectService) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
     // TODO: All traffic to routes other than `/projects` will check project ID validity
+    next();
   }
 }

--- a/packages/server/src/project/project.guard.ts
+++ b/packages/server/src/project/project.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable, NestMiddleware } from '@nestjs/common';
+import { HttpStatus, Injectable, NestMiddleware } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
 import { ProjectService } from './project.service';
 
@@ -8,6 +8,11 @@ export class ProjectGuard implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction): void {
     // TODO: All traffic to routes other than `/projects` will check project ID validity
+    if (!this.projectService.exists(req.body.projectId)) {
+      res.status(HttpStatus.BAD_REQUEST).send('Project ID does not exist');
+      return;
+    }
+
     next();
   }
 }

--- a/packages/server/src/project/project.guard.ts
+++ b/packages/server/src/project/project.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction } from 'express';
+
+@Injectable()
+export class ProjectGuard implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    // TODO: All traffic to routes other than `/projects` will check project ID validity
+  }
+}

--- a/packages/server/src/project/project.guard.ts
+++ b/packages/server/src/project/project.guard.ts
@@ -6,9 +6,8 @@ import { ProjectService } from './project.service';
 export class ProjectGuard implements NestMiddleware {
   constructor(private readonly projectService: ProjectService) {}
 
-  use(req: Request, res: Response, next: NextFunction): void {
-    // TODO: All traffic to routes other than `/projects` will check project ID validity
-    if (!this.projectService.exists(req.body.projectId)) {
+  async use(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (!(await this.projectService.exists(req.body.projectId))) {
       res.status(HttpStatus.BAD_REQUEST).send('Project ID does not exist');
       return;
     }

--- a/packages/server/src/project/project.module.ts
+++ b/packages/server/src/project/project.module.ts
@@ -6,6 +6,7 @@ import { ProjectPipe } from './project.pipe';
 
 @Module({
   providers: [ProjectService, PrismaService, ProjectPipe],
-  controllers: [ProjectController]
+  controllers: [ProjectController],
+  exports: [ProjectService]
 })
 export class ProjectModule {}


### PR DESCRIPTION
# Description

> `ProjectGuard` will be implemented as a middleware. This middleware will intercept all traffic that go to routes other than `/projects` and `/health`, and check if the project ID exists in the database.

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
