### PR TITLE
Case-insensitive email

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -1,7 +1,18 @@
 import { Body, Controller, Post, UsePipes, ValidationPipe } from '@nestjs/common';
 import { UpdateStatus } from '../user/types/user.types';
 import { AuthService } from './auth.service';
-import { UsernameLoginTransformPipe, EmailLoginTransformPipe, SignupTransformPipe, UserSignupDto, EmailLoginDto, UsernameLoginDto, ForgotDto, ResetDto } from './dto/auth.dto';
+import {
+  UsernameLoginTransformPipe,
+  EmailLoginTransformPipe,
+  SignupTransformPipe,
+  UserSignupDto,
+  EmailLoginDto,
+  UsernameLoginDto,
+  ForgotDto,
+  ResetDto,
+  ResetPasswordTransformPipe,
+  ForgotPasswordTransformPipe
+} from './dto/auth.dto';
 import { AccessToken } from './types/auth.types';
 
 @Controller('login')
@@ -37,11 +48,13 @@ export class RecoveryController {
   constructor(private authService: AuthService) {}
 
   @Post('forgot')
+  @UsePipes(new ForgotPasswordTransformPipe())
   async forgotPassword(@Body() user: ForgotDto): Promise<void> {
     return this.authService.forgotPassword(user.projectId, user.email);
   }
 
   @Post('reset')
+  @UsePipes(new ResetPasswordTransformPipe())
   async resetPassword(@Body() user: ResetDto): Promise<UpdateStatus> {
     return this.authService.resetPassword(user.projectId, user.email, user.password, user.code);
   }

--- a/packages/server/src/auth/auth.resolver.ts
+++ b/packages/server/src/auth/auth.resolver.ts
@@ -1,7 +1,8 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { AccessToken } from './types/auth.types';
-import { EmailLoginDto, ForgotDto, ResetDto, UsernameLoginDto, UserSignupDto } from './dto/auth.dto';
+import { EmailLoginDto, EmailLoginTransformPipe, ForgotDto, ForgotPasswordTransformPipe, ResetDto, ResetPasswordTransformPipe, UsernameLoginDto, UserSignupDto } from './dto/auth.dto';
+import { UsePipes } from '@nestjs/common';
 
 @Resolver()
 export class AuthResolver {
@@ -15,6 +16,7 @@ export class AuthResolver {
 
   /** Login via email */
   @Mutation(() => AccessToken)
+  @UsePipes(new EmailLoginTransformPipe())
   async loginEmail(@Args('user') user: EmailLoginDto): Promise<AccessToken> {
     return this.authService.validateEmail(user.projectId, user.email, user.password);
   }
@@ -27,6 +29,7 @@ export class AuthResolver {
 
   /** Forgot password */
   @Mutation(() => Boolean)
+  @UsePipes(new ForgotPasswordTransformPipe())
   async forgotPassword(@Args('user') user: ForgotDto): Promise<boolean> {
     await this.authService.forgotPassword(user.projectId, user.email);
 
@@ -36,6 +39,7 @@ export class AuthResolver {
 
   /** Reset password */
   @Mutation(() => Boolean)
+  @UsePipes(new ResetPasswordTransformPipe())
   async resetPassword(@Args('user') user: ResetDto): Promise<boolean> {
     await this.authService.resetPassword(user.projectId, user.email, user.password, user.code);
 

--- a/packages/server/src/auth/auth.resolver.ts
+++ b/packages/server/src/auth/auth.resolver.ts
@@ -1,7 +1,16 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { AccessToken } from './types/auth.types';
-import { EmailLoginDto, EmailLoginTransformPipe, ForgotDto, ForgotPasswordTransformPipe, ResetDto, ResetPasswordTransformPipe, UsernameLoginDto, UserSignupDto } from './dto/auth.dto';
+import {
+  EmailLoginDto,
+  EmailLoginTransformPipe,
+  ForgotDto,
+  ForgotPasswordTransformPipe,
+  ResetDto,
+  ResetPasswordTransformPipe,
+  UsernameLoginDto,
+  UserSignupDto
+} from './dto/auth.dto';
 import { UsePipes } from '@nestjs/common';
 
 @Resolver()

--- a/packages/server/src/auth/dto/auth.dto.ts
+++ b/packages/server/src/auth/dto/auth.dto.ts
@@ -118,7 +118,7 @@ export class SignupTransformPipe implements PipeTransform {
 
     user.projectId = body.projectId.toString();
     user.username = body.username.toString();
-    user.email = body.email.toString();
+    user.email = body.email.toString().toLowerCase();
     user.password = body.password;
 
     return user;
@@ -142,8 +142,32 @@ export class EmailLoginTransformPipe implements PipeTransform {
     const user = new UserSignupDto();
 
     user.projectId = body.projectId.toString();
-    user.email = body.email;
+    user.email = body.email.toLowerCase();
     user.password = body.password;
+
+    return user;
+  }
+}
+
+export class ForgotPasswordTransformPipe implements PipeTransform {
+  transform(body: any): ForgotDto {
+    const user = new ForgotDto();
+
+    user.projectId = body.projectId.toString();
+    user.email = body.email.toLowerCase();
+
+    return user;
+  }
+}
+
+export class ResetPasswordTransformPipe implements PipeTransform {
+  transform(body: any): ResetDto {
+    const user = new ResetDto();
+
+    user.projectId = body.projectId.toString();
+    user.email = body.email.toLowerCase();
+    user.password = body.password;
+    user.code = body.code;
 
     return user;
   }


### PR DESCRIPTION
# Description

/email, /signup, /forgot, and /reset use transformation pipes to make email lowercase

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
