### PR TITLE
fix(backup-timezone): write cron expression in UTC...

### DIFF
--- a/backup.env
+++ b/backup.env
@@ -5,7 +5,7 @@
 # to ever run, use `0 0 5 31 2 ?`.
 
 # sail auth service: back up on Monday mornings
-BACKUP_CRON_EXPRESSION="20 4 * * 1"
+BACKUP_CRON_EXPRESSION="20 8 * * 1"
 # BACKUP_CRON_EXPRESSION="0 2 * * *"
 
 # The name of the backup file including the `.tar.gz` extension.


### PR DESCRIPTION
# Description

The backup.env cron expression is in UTC, so just shifting it 4 hours... :facepalm: (EDT = UTC -4)

## Checklist

- [x ] This PR can be reviewed in under 30 minutes
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have assigned reviewers to this PR.
