### PR TITLE
Fix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ This section outlines the steps to set up the Authentication Service for local d
 Ensure you have the following software installed on your machine:
 
 1. [Docker](https://docs.docker.com/get-docker/)
-2. [Node.js](https://nodejs.org/en/download/)
-3. [npm](https://www.npmjs.com/get-npm)
+1. [Node.js](https://nodejs.org/en/download/)
+1. [npm](https://www.npmjs.com/get-npm)
 
 ## Setup Instructions
 
@@ -56,39 +56,39 @@ Ensure you have the following software installed on your machine:
     cd packages/server
     ```
 
-2. Build and run the Docker Compose file:
+1. Build and run the Docker Compose file:
 
     ```
     docker-compose up -d --build
     ```
 
-3. Install the project's npm dependencies:
+1. Install the project's npm dependencies:
 
     ```
     npm i
     ```
 
-4. Generate Prisma Client JS:
+1. Generate Prisma Client JS:
 
     ```
     npm run prisma:generate
     ```
 
-5. Run Prisma migrations to set up your database schema:
+1. Run Prisma migrations to set up your database schema:
 
     ```
     npm run prisma:migrate
     ```
 
-6. Start the development server:
+1. Start the development server:
 
     ```
     npm run start:dev
     ```
 
-7. Access the GraphQL Playground at [http://localhost:3001/graphql](http://localhost:3001/graphql).
+1. Access the GraphQL Playground at [http://localhost:3001/graphql](http://localhost:3001/graphql).
 
-8. To create a project, use the following GraphQL mutation:
+1. To create a project, use the following GraphQL mutation:
 
     ```graphql
     mutation {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Ensure you have the following software installed on your machine:
     docker-compose up -d --build
     ```
 
+1. Set environment variables:
+
+    ```
+    source .env.test
+    ```
+
 1. Install the project's npm dependencies:
 
     ```


### PR DESCRIPTION
# Description

At present, if someone follows the local dev setup instructions verbatim, the docker-compose file that actually gets run upon `docker compose up` is the one at the top level of this repo (not either of the docker-compose files in packages/server); that docker-compose file sets environment variables from .env.test, in particular the db username and password. Then upon running the prisma migrate step, there will be db auth errors if the environment variables in that shell are not also set according to .env.test.

I don't know what the intended steps are supposed to be (is the db actually supposed to be spun up from one of the other docker-compose files?) so this was just the quickest path to instructions that don't result in errors; just close this PR if not appropriate 

## Checklist

- [x ] This PR can be reviewed in under 30 minutes
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have assigned reviewers to this PR.
